### PR TITLE
Call toString method on path params

### DIFF
--- a/modules/swagger-codegen/src/main/resources/gwt-client/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwt-client/api.mustache
@@ -52,7 +52,7 @@ import java.util.*;
     public void {{gwtphpClientMethodName}}({{#allParams}}{{#fnToWrapper}}{{dataType}}{{/fnToWrapper}} {{paramName}}, {{/allParams}}final ApiCallback<{{#fnJsArray}}{{returnType}}{{/fnJsArray}}> callback) {
         String callUrl = "{{path}}";
         {{#pathParams}}
-        callUrl = callUrl.replace("{{#fnCurly}}{{baseName}}{{/fnCurly}}", {{paramName}});
+        callUrl = callUrl.replace("{{#fnCurly}}{{baseName}}{{/fnCurly}}", {{paramName}}.toString());
         {{/pathParams}}
 
         RequestCallback requestCallback = new RequestCallback() {


### PR DESCRIPTION
convert parameters to string (because of `type: number`)