### PR TITLE
variable names sanitization, XSS fix, response content-type

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GwtClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GwtClientCodegen.java
@@ -107,6 +107,14 @@ public class GwtClientCodegen extends DefaultCodegen implements CodegenConfig {
       return fragment.toUpperCase();
     }
   }
+  
+  private static class SanitizeVariableNameLambda extends CustomLambda {
+    @Override
+    public String formatFragment(String fragment) {
+      return GwtClientCodegen.sanitizeVariableName(fragment);
+    }
+  }
+  
   private static final String LANGUAGE_NAME = "gwt-client";
 
   private static final String CODEGEN_VERSION = "1.2.1";
@@ -159,6 +167,25 @@ public class GwtClientCodegen extends DefaultCodegen implements CodegenConfig {
     typeMapping.put("integer", "int");
   }
 
+  public static String sanitizeVariableName(String name) {
+    name = name.replaceAll("\\+", "PLUS");
+    name = name.replaceAll("\\*", "STAR");
+    name = name.replaceAll("\\?", "QUESTION_MARK");
+    name = name.replaceAll("\\$", "DOLLAR");
+    name = name.replaceAll("-$", "MINUS");
+    name = name.replaceAll("-", "");
+    name = name.replaceAll("!", "EXCLAMATION_MARK");
+    name = name.replaceAll("#", "HASH");
+    name = name.replaceAll("~", "TILDE");
+    name = name.replaceAll("@", "AT");
+    name = name.replaceAll("%", "PERCENT");
+    name = name.replaceAll("&", "AMPERSAND");
+    name = name.replaceAll("=", "EQUAL");
+    name = name.replaceAll(":", "COLON");
+    name = name.replaceAll(";", "SEMICOLON");
+    return name;
+  }
+  
   @Override
   public CodegenOperation fromOperation(String path, String httpMethod,
       Operation operation, Map<String, Model> definitions, Swagger swagger) {
@@ -242,6 +269,7 @@ public class GwtClientCodegen extends DefaultCodegen implements CodegenConfig {
     additionalProperties.put("fnCamelize", new CamelizeLambda());
     additionalProperties.put("fnCurly", new CurlyLambda());
     additionalProperties.put("fnToWrapper", new ToWrapperLambda());
+    additionalProperties.put("fnSanitizeVariableName", new SanitizeVariableNameLambda());
 
     supportingFiles.add(new SupportingFile("ApiCallback.mustache",
         supportPackageFolder(), "ApiCallback.java"));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GwtClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GwtClientCodegen.java
@@ -173,14 +173,14 @@ public class GwtClientCodegen extends DefaultCodegen implements CodegenConfig {
     name = name.replaceAll("\\?", "QUESTION_MARK");
     name = name.replaceAll("\\$", "DOLLAR");
     name = name.replaceAll("-$", "MINUS");
-    name = name.replaceAll("-", "");
+    name = name.replaceAll("-", "_");
     name = name.replaceAll("!", "EXCLAMATION_MARK");
     name = name.replaceAll("#", "HASH");
     name = name.replaceAll("~", "TILDE");
     name = name.replaceAll("@", "AT");
     name = name.replaceAll("%", "PERCENT");
     name = name.replaceAll("&", "AMPERSAND");
-    name = name.replaceAll("=", "EQUAL");
+    name = name.replaceAll("=", "EQUALS");
     name = name.replaceAll(":", "COLON");
     name = name.replaceAll(";", "SEMICOLON");
     return name;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GwtPhpServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GwtPhpServerCodegen.java
@@ -301,6 +301,7 @@ public class GwtPhpServerCodegen extends DefaultCodegen
         {"restapi/", "", "Auth.class.php"},
         {"restapi/", "", "Params.class.php"},
         {"restapi/", "", "ProcessingException.class.php"},
+        {"restapi/", "", "FieldValidityException.class.php"},
         {"restapi/", "", "HasHeaders.class.php"},
         {"restapi/", "", "HeadersTrait.class.php"},
         {"restapi/", "", "Response.class.php"},

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GwtPhpServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GwtPhpServerCodegen.java
@@ -301,6 +301,8 @@ public class GwtPhpServerCodegen extends DefaultCodegen
         {"restapi/", "", "Auth.class.php"},
         {"restapi/", "", "Params.class.php"},
         {"restapi/", "", "ProcessingException.class.php"},
+        {"restapi/", "", "HasHeaders.class.php"},
+        {"restapi/", "", "HeadersTrait.class.php"},
         {"restapi/", "", "Response.class.php"},
         {"restapi/", "", "Make.class.php"},
         {"restapi/", "", "Result.class.php"},

--- a/modules/swagger-codegen/src/main/resources/gwt-client/DefaultInterceptor.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwt-client/DefaultInterceptor.mustache
@@ -9,6 +9,10 @@
 
 package {{supportPackage}};
 
+/**
+ * Auto generated code from swagger api description. DO NOT EDIT !!!!
+ * Codegen version: {{codegenVersion}}
+ */
 public class DefaultInterceptor implements Interceptor {
 
   public String buildBaseUrl(String baseUrl) {

--- a/modules/swagger-codegen/src/main/resources/gwt-client/Interceptor.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwt-client/Interceptor.mustache
@@ -9,6 +9,10 @@
 
 package {{supportPackage}};
 
+/**
+ * Auto generated code from swagger api description. DO NOT EDIT !!!!
+ * Codegen version: {{codegenVersion}}
+ */
 public interface Interceptor {
 
   String buildBaseUrl(String baseUrl);

--- a/modules/swagger-codegen/src/main/resources/gwt-client/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwt-client/model.mustache
@@ -22,7 +22,7 @@ import {{supportPackage}}.ValidationException;
  */
 public class {{classname}} extends JavaScriptObject {
 {{#vars}}{{#isEnum}}{{#allowableValues}}{{#values}}
-    public static final String {{#fnUpperCase}}{{name}}_{{{this}}}{{/fnUpperCase}} = "{{{this}}}";{{/values}}{{/allowableValues}}{{/isEnum}}{{/vars}}
+    public static final String {{#fnUpperCase}}{{name}}_{{#fnSanitizeVariableName}}{{{this}}}{{/fnSanitizeVariableName}}{{/fnUpperCase}} = "{{{this}}}";{{/values}}{{/allowableValues}}{{/isEnum}}{{/vars}}
 
     public static {{classname}} create() {
         return JavaScriptObject.createObject().cast();

--- a/modules/swagger-codegen/src/main/resources/gwtphp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/api.mustache
@@ -36,14 +36,14 @@
         }{{/required}}{{/allParams}}
         $resourcePath = "{{path}}";
         $httpBody = '';
-        $queryParams = array();
-        $headerParams = array();
-        $formParams = array();
-        $_header_accept = $this->apiClient->selectHeaderAccept(array({{#produces}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}}));
+        $queryParams = [];
+        $headerParams = [];
+        $formParams = [];
+        $_header_accept = $this->apiClient->selectHeaderAccept([{{#produces}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}}]);
         if (!is_null($_header_accept)) {
             $headerParams['Accept'] = $_header_accept;
         }
-        $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array({{#consumes}}'{{mediaType}}'{{#hasMore}},{{/hasMore}}{{/consumes}}));
+        $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType([{{#consumes}}'{{mediaType}}'{{#hasMore}},{{/hasMore}}{{/consumes}}]);
         {{#queryParams}}{{#collectionFormat}}
         if (is_array(${{paramName}})) {
             ${{paramName}} = RestApi_Client_Utils::serializeCollection(${{paramName}}, '{{collectionFormat}}', true);
@@ -98,20 +98,20 @@
                 $headerParams{{#returnType}}, '{{returnType}}'{{/returnType}}
             );{{#returnType}}
             if (!is_array($response) && !$response) {
-                return array(null, $statusCode, $httpHeader);
+                return [null, $statusCode, $httpHeader];
             }{{#isListContainer}}
-            $responseObject = array();
+            $responseObject = [];
             foreach($response as $item) {
                 $responseObject[] = new {{#fnItemType}}{{returnType}}{{/fnItemType}}($item);
             }
-            return array($responseObject, $statusCode, $httpHeader);{{/isListContainer}}{{^isListContainer}}{{#returnTypeIsPrimitive}}
-            return array($response, $statusCode, $httpHeader);{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}
-            return array(new {{returnType}}($response), $statusCode, $httpHeader);{{/returnTypeIsPrimitive}}{{/isListContainer}}{{/returnType}}{{^returnType}}
-            return array(null, $statusCode, $httpHeader);{{/returnType}}
+            return [$responseObject, $statusCode, $httpHeader];{{/isListContainer}}{{^isListContainer}}{{#returnTypeIsPrimitive}}
+            return [$response, $statusCode, $httpHeader];{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}
+            return [new {{returnType}}($response), $statusCode, $httpHeader];{{/returnTypeIsPrimitive}}{{/isListContainer}}{{/returnType}}{{^returnType}}
+            return [null, $statusCode, $httpHeader];{{/returnType}}
         } catch (RestApi_Client_ApiException $e) {
             switch ($e->getCode()) { {{#responses}}{{#dataType}}
             {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}{{^simpleType}}
-                $data = array();
+                $data = [];
                 foreach($e->getResponseBody() as $item) {
                     $data[] = new {{#fnItemType}}{{dataType}}{{/fnItemType}}($item);
                 }

--- a/modules/swagger-codegen/src/main/resources/gwtphp/client/ApiClient.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/client/ApiClient.php
@@ -55,7 +55,7 @@ class RestApi_Client_ApiClient {
             throw new InvalidArgumentException('Api client host not specified.');
         }
 
-        $headers = array();
+        $headers = [];
 
         if ($this->getAccessToken() != '') {
             $headerParams['apikey'] = $this->getAccessToken();
@@ -141,7 +141,7 @@ class RestApi_Client_ApiClient {
         if ($response_info['http_code'] >= 200 && $response_info['http_code'] <= 299) {
             // return raw body if response is a file
             if ($responseType === 'file' || $responseType === 'string') {
-                return array($http_body, $response_info['http_code'], $http_header);
+                return [$http_body, $response_info['http_code'], $http_header];
             }
 
             $data = json_decode($http_body, true);
@@ -160,7 +160,7 @@ class RestApi_Client_ApiClient {
             );
         }
 
-        return array($data, $response_info['http_code'], $http_header);
+        return [$data, $response_info['http_code'], $http_header];
     }
 
     /**
@@ -260,7 +260,7 @@ class RestApi_Client_ApiClient {
      */
     protected function http_parse_headers($raw_headers) {
         // ref/credit: http://php.net/manual/en/function.http-parse-headers.php#112986
-        $headers = array();
+        $headers = [];
         $key = '';
 
         foreach (explode("\n", $raw_headers) as $h) {
@@ -270,14 +270,14 @@ class RestApi_Client_ApiClient {
                 if (!isset($headers[$h[0]])) {
                     $headers[$h[0]] = trim($h[1]);
                 } elseif (is_array($headers[$h[0]])) {
-                    $headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1])));
+                    $headers[$h[0]] = array_merge($headers[$h[0]], [trim($h[1])]);
                 } else {
-                    $headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1])));
+                    $headers[$h[0]] = array_merge([$headers[$h[0]]], [trim($h[1])]);
                 }
 
                 $key = $h[0];
             } else {
-                if (substr($h[0], 0, 1) == "\t") {
+                if (substr($h[0], 0, 1) === "\t") {
                     $headers[$key] .= "\r\n\t" . trim($h[0]);
                 } elseif (!$key) {
                     $headers[0] = trim($h[0]);

--- a/modules/swagger-codegen/src/main/resources/gwtphp/field/BoolField.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/field/BoolField.class.php
@@ -11,8 +11,8 @@
  * Auto generated code. DO NOT EDIT !!!!
  */
 class RestApi_TypeUtils_BoolField extends RestApi_TypeUtils_Field {
-    private static $true = array('true', 'y');
-    private static $false = array('false', 'n', '');
+    private static $true = ['true', 'y'];
+    private static $false = ['false', 'n', ''];
 
     /**
      * @param mixed $value

--- a/modules/swagger-codegen/src/main/resources/gwtphp/field/Field.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/field/Field.class.php
@@ -104,7 +104,7 @@ class ArrayField extends RestApi_TypeUtils_Field {
 
     public function __construct(RestApi_TypeUtils_Field $type) {
         $this->type = $type;
-        $this->setDefaultValue(array());
+        $this->setDefaultValue([]);
     }
 
     /**
@@ -114,9 +114,9 @@ class ArrayField extends RestApi_TypeUtils_Field {
      */
     protected function parse($value) {
         if (!is_array($value)) {
-            return array();
+            return [];
         }
-        $result = array();
+        $result = [];
         foreach ($value as $key => $item) {
             $result[$key] = $this->type->parse($item);
         }

--- a/modules/swagger-codegen/src/main/resources/gwtphp/field/ParseException.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/field/ParseException.class.php
@@ -12,30 +12,11 @@
  */
 class RestApi_TypeUtils_ParseException extends Exception {
 
-    /** @var string */
-    private $fieldName;
-
     /**
      * @param string $type
      * @param string $value
-     * @param string $fieldName
      */
-    public function __construct($type, $value, $fieldName = '_unset_') {
-        parent::__construct("Unable to convert '" . $value . "' to " . $type . '.', 403);
-        $this->fieldName = $fieldName;
-    }
-
-    /**
-     * @return string
-     */
-    public function getFieldName() {
-        return $this->fieldName;
-    }
-
-    /**
-     * @param string $fieldName
-     */
-    public function setFieldName($fieldName) {
-        $this->fieldName = $fieldName;
+    public function __construct($type, $value) {
+        parent::__construct("Unable to convert '" . $value . "' to " . $type . '.');
     }
 }

--- a/modules/swagger-codegen/src/main/resources/gwtphp/field/ParseException.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/field/ParseException.class.php
@@ -12,17 +12,29 @@
  */
 class RestApi_TypeUtils_ParseException extends Exception {
 
+    /** @var string */
     private $fieldName;
 
-    public function __construct($type, $value, $fieldName = null) {
+    /**
+     * @param string $type
+     * @param string $value
+     * @param string $fieldName
+     */
+    public function __construct($type, $value, $fieldName = '_unset_') {
         parent::__construct("Unable to convert '" . $value . "' to " . $type . '.', 403);
         $this->fieldName = $fieldName;
     }
 
+    /**
+     * @return string
+     */
     public function getFieldName() {
         return $this->fieldName;
     }
 
+    /**
+     * @param string $fieldName
+     */
     public function setFieldName($fieldName) {
         $this->fieldName = $fieldName;
     }

--- a/modules/swagger-codegen/src/main/resources/gwtphp/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/index.mustache
@@ -41,10 +41,10 @@ $app->notFound(function () use ($app) {
  * {{notes}}
  */
 $app->{{#fnLowerCase}}{{httpMethod}}{{/fnLowerCase}}('{{#fnSlimPath}}{{path}}{{/fnSlimPath}}', function ({{#pathParams}}${{paramName}}{{#hasMore}}, {{/hasMore}}{{/pathParams}}) use ($app, $auth) {
-    $params = new RestApi_Params($app->request(){{#authMethods}}, array({{#scopes}}'{{scope}}'{{#hasMore}}, {{/hasMore}}{{/scopes}}){{/authMethods}});
+    $params = new RestApi_Params($app->request(){{#authMethods}}, [{{#scopes}}'{{scope}}'{{#hasMore}}, {{/hasMore}}{{/scopes}}]{{/authMethods}});
     $response = new RestApi_Response($app->response());
     try { {{#allParams}}{{^isPathParam}}{{^isBodyParam}}
-        $params->check('{{paramName}}', {{#required}}true{{/required}}{{^required}}false{{/required}}, '{{defaultValue}}', '{{dataType}}', {{#isEnum}}array({{#allowableValues}}{{#values}}'{{.}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}{{^isEnum}}null{{/isEnum}});{{/isBodyParam}}{{/isPathParam}}{{/allParams}}{{#authMethods}}{{#isOAuth}}
+        $params->check('{{paramName}}', {{#required}}true{{/required}}{{^required}}false{{/required}}, '{{defaultValue}}', '{{dataType}}', {{#isEnum}}[{{#allowableValues}}{{#values}}'{{.}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}]{{/isEnum}}{{^isEnum}}null{{/isEnum}});{{/isBodyParam}}{{/isPathParam}}{{/allParams}}{{#authMethods}}{{#isOAuth}}
         $auth->checkScope($params->getScopes());{{/isOAuth}}{{/authMethods}}{{#bodyParam}}{{^dataType}}
         $data = $params->getBody(){{/dataType}}{{#dataType}}
         $data = new {{dataType}}($params->getBody());

--- a/modules/swagger-codegen/src/main/resources/gwtphp/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/index.mustache
@@ -44,7 +44,7 @@ $app->{{#fnLowerCase}}{{httpMethod}}{{/fnLowerCase}}('{{#fnSlimPath}}{{path}}{{/
     $params = new RestApi_Params($app->request(){{#authMethods}}, [{{#scopes}}'{{scope}}'{{#hasMore}}, {{/hasMore}}{{/scopes}}]{{/authMethods}});
     $response = new RestApi_Response($app->response());
     try { {{#allParams}}{{^isPathParam}}{{^isBodyParam}}
-        $params->check('{{paramName}}', {{#required}}true{{/required}}{{^required}}false{{/required}}, '{{defaultValue}}', '{{dataType}}', {{#isEnum}}[{{#allowableValues}}{{#values}}'{{.}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}]{{/isEnum}}{{^isEnum}}null{{/isEnum}});{{/isBodyParam}}{{/isPathParam}}{{/allParams}}{{#authMethods}}{{#isOAuth}}
+        $params->check('{{paramName}}', {{#required}}true{{/required}}{{^required}}false{{/required}}, '{{defaultValue}}', '{{dataType}}', {{#isEnum}}[{{#allowableValues}}{{#values}}'{{.}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}]{{/isEnum}}{{^isEnum}}[]{{/isEnum}});{{/isBodyParam}}{{/isPathParam}}{{/allParams}}{{#authMethods}}{{#isOAuth}}
         $auth->checkScope($params->getScopes());{{/isOAuth}}{{/authMethods}}{{#bodyParam}}{{^dataType}}
         $data = $params->getBody(){{/dataType}}{{#dataType}}
         $data = new {{dataType}}($params->getBody());

--- a/modules/swagger-codegen/src/main/resources/gwtphp/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/index.mustache
@@ -14,6 +14,7 @@
 require '../../scripts/bootstrap_api.php';
 
 $app = new \Slim\Slim();
+$app->contentType('application/json');
 
 try {
     RestApi_Make::init(new {{apiPackage}}_Make());
@@ -28,6 +29,12 @@ try {
     $response->send();
     exit();
 }
+
+$app->notFound(function () use ($app) {
+    $app->halt(404, RestApi_Make::errorMessage(
+            sprintf('Page Not Found. The API method %s could not be found.', $app->request()->getPathInfo())
+    ));
+});
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 /*
  * {{notes}}

--- a/modules/swagger-codegen/src/main/resources/gwtphp/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/index.mustache
@@ -31,9 +31,10 @@ try {
 }
 
 $app->notFound(function () use ($app) {
-    $app->halt(404, RestApi_Make::errorMessage(
+    echo RestApi_Make::errorResult(
+            0, // not used
             sprintf('Page Not Found. The API method %s could not be found.', $app->request()->getPathInfo())
-    ));
+    )->getBody();
 });
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 /*

--- a/modules/swagger-codegen/src/main/resources/gwtphp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/model.mustache
@@ -15,7 +15,7 @@
  */
 class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHeaders {
 
-	use RestApi_HeadersTrait;
+    use RestApi_HeadersTrait;
 
     {{#vars}}const {{#fnUpperCase}}{{name}}{{/fnUpperCase}} = '{{name}}';{{#hasMore}}
     {{/hasMore}}{{/vars}}
@@ -31,18 +31,17 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
     /**
      * Constructor
      * @param mixed[] $data Associated array of property value initalizing the model
-     * @throws RestApi_TypeUtils_ParseException
+     * @throws RestApi_FieldValidityException
      */
     public function __construct($data = null) {
         if ($data === null || !is_array($data)) {
             $data = [];
         }
-        foreach (self::$fieldTypes as $name => $info) {
+        foreach (self::$fieldTypes as $fieldName => $info) {
             try {
-                $this->data[$name] = RestApi_TypeUtils_Field::of($info[0], @$data[$name], @$info[1]);
+                $this->data[$fieldName] = RestApi_TypeUtils_Field::of($info[0], @$data[$fieldName], @$info[1]);
             } catch (RestApi_TypeUtils_ParseException $e) {
-                $e->setFieldName($name);
-                throw $e;
+                throw new RestApi_FieldValidityException($fieldName, $e->getMessage())
             }
         }
     }
@@ -52,9 +51,9 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
      */
     public function getData() {
         $result = [];
-        foreach($this->data as $name => $field) {
+        foreach($this->data as $fieldName => $field) {
             if($field->get() !== null) {
-                $result[$name] = $field->get();
+                $result[$fieldName] = $field->get();
             }
         }
         return $result;
@@ -86,7 +85,6 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
      * Sets {{name}}
      * @param {{datatype}} ${{name}} {{#description}}{{{description}}}{{/description}}
      * @return $this
-     * @throws RestApi_TypeUtils_ParseException
      * @throws \InvalidArgumentException
      */
     public function {{setter}}({{^isContainer}}{{^isPrimitiveType}}{{datatype}} {{/isPrimitiveType}}{{/isContainer}}{{#isContainer}}array {{/isContainer}}${{name}}) { {{#isEnum}}
@@ -99,9 +97,13 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
         foreach (${{name}} as $item) {
             $data[] = $item->getData();
         }
-        $this->data['{{name}}']->set($data);{{/isPrimitiveType}}{{#isPrimitiveType}}
-        $this->data['{{name}}']->set(${{name}});{{/isPrimitiveType}}{{/isContainer}}{{^isContainer}}
-        $this->data['{{name}}']->set(${{name}}{{^isPrimitiveType}}->getData(){{/isPrimitiveType}});{{/isContainer}}
+        try {
+            $this->data['{{name}}']->set($data);{{/isPrimitiveType}}{{#isPrimitiveType}}
+            $this->data['{{name}}']->set(${{name}});{{/isPrimitiveType}}{{/isContainer}}{{^isContainer}}
+            $this->data['{{name}}']->set(${{name}}{{^isPrimitiveType}}->getData(){{/isPrimitiveType}});{{/isContainer}}
+        } catch (RestApi_TypeUtils_ParseException $e) {
+            throw new \InvalidArgumentException($e->getMessage())
+        }
         return $this;
     }
 {{/vars}}

--- a/modules/swagger-codegen/src/main/resources/gwtphp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/model.mustache
@@ -13,7 +13,9 @@
  * Auto generated code from swagger api description. DO NOT EDIT !!!!
  * Codegen version: {{codegenVersion}}
  */
-class {{modelPackage}}_{{classname}} {
+class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHeaders {
+
+	use RestApi_HeadersTrait;
 
     {{#vars}}const {{#fnUpperCase}}{{name}}{{/fnUpperCase}} = '{{name}}';{{#hasMore}}
     {{/hasMore}}{{/vars}}
@@ -56,6 +58,10 @@ class {{modelPackage}}_{{classname}} {
             }
         }
         return $result;
+    }
+    
+    public function jsonSerialize() {
+        return $this->getData();
     }
 {{#vars}}
     /**

--- a/modules/swagger-codegen/src/main/resources/gwtphp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/model.mustache
@@ -20,13 +20,13 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
     {{#vars}}const {{#fnUpperCase}}{{name}}{{/fnUpperCase}} = '{{name}}';{{#hasMore}}
     {{/hasMore}}{{/vars}}
 
-    private static $fieldTypes = array({{#vars}}
-            '{{name}}' => array('{{#isPrimitiveType}}{{datatype}}{{/isPrimitiveType}}{{^isPrimitiveType}}mixed[]{{/isPrimitiveType}}'{{#hasDefaultValue}}, {{{defaultValue}}}{{/hasDefaultValue}}){{#hasMore}},{{/hasMore}}{{/vars}});
+    private static $fieldTypes = [{{#vars}}
+            '{{name}}' => ['{{#isPrimitiveType}}{{datatype}}{{/isPrimitiveType}}{{^isPrimitiveType}}mixed[]{{/isPrimitiveType}}'{{#hasDefaultValue}}, {{{defaultValue}}}{{/hasDefaultValue}}]{{#hasMore}},{{/hasMore}}{{/vars}}];
 
     /**
      * @var RestApi_TypeUtils_Field[]
      */
-    private $data = array();
+    private $data = [];
 
     /**
      * Constructor
@@ -35,7 +35,7 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
      */
     public function __construct($data = null) {
         if ($data === null || !is_array($data)) {
-            $data = array();
+            $data = [];
         }
         foreach (self::$fieldTypes as $name => $info) {
             try {
@@ -51,7 +51,7 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
      * @return mixed[]
      */
     public function getData() {
-        $result = array();
+        $result = [];
         foreach($this->data as $name => $field) {
             if($field->get() !== null) {
                 $result[$name] = $field->get();
@@ -69,13 +69,13 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
      * @return {{datatype}}
      */
     public function {{getter}}() { {{^isPrimitiveType}}{{#isContainer}}
-        $data = array();
+        $data = [];
         foreach ($this->data['{{name}}']->get() as $item) {
            $data[] = new {{#fnItemType}}{{datatype}}{{/fnItemType}}($item);
         }
         return $data;{{/isContainer}}{{^isContainer}}
         $data = $this->data['{{name}}']->get();
-        if($data === array()) {
+        if($data === []) {
             return null;
         }
         return new {{datatype}}($data);{{/isContainer}}{{/isPrimitiveType}}{{#isPrimitiveType}}
@@ -90,12 +90,12 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
      * @throws \InvalidArgumentException
      */
     public function {{setter}}({{^isContainer}}{{^isPrimitiveType}}{{datatype}} {{/isPrimitiveType}}{{/isContainer}}{{#isContainer}}array {{/isContainer}}${{name}}) { {{#isEnum}}
-        $allowed_values = array({{#allowableValues}}{{#values}}"{{{this}}}"{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}});
+        $allowed_values = [{{#allowableValues}}{{#values}}"{{{this}}}"{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}];
         if (!in_array(${{{name}}}, $allowed_values)) {
             throw new \InvalidArgumentException("Invalid value for '{{name}}', must be one of {{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}");
         }
         {{/isEnum}}{{#isContainer}}{{^isPrimitiveType}}
-        $data = array();
+        $data = [];
         foreach (${{name}} as $item) {
             $data[] = $item->getData();
         }
@@ -125,7 +125,7 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
         {{#isPrimitiveType}}if ($this->{{getter}}() == '') {
             throw RestApi_Make::error(400, '{{name}} is required');
         }{{/isPrimitiveType}}{{^isPrimitiveType}}$this->{{getter}}()->check();{{/isPrimitiveType}}{{/required}}{{#isEnum}}
-        $allowed_values = array({{#allowableValues}}{{#values}}"{{{this}}}"{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}});
+        $allowed_values = [{{#allowableValues}}{{#values}}"{{{this}}}"{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}];
         if (!in_array($this->{{getter}}(), $allowed_values)) {
             throw RestApi_Make::error(400, "Invalid value for '{{name}}', must be one of {{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}");
         }{{/isEnum}}{{/vars}}

--- a/modules/swagger-codegen/src/main/resources/gwtphp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/model.mustache
@@ -41,7 +41,7 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
             try {
                 $this->data[$fieldName] = RestApi_TypeUtils_Field::of($info[0], @$data[$fieldName], @$info[1]);
             } catch (RestApi_TypeUtils_ParseException $e) {
-                throw new RestApi_FieldValidityException($fieldName, $e->getMessage())
+                throw new RestApi_FieldValidityException($fieldName, $e->getMessage());
             }
         }
     }
@@ -97,12 +97,13 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
         foreach (${{name}} as $item) {
             $data[] = $item->getData();
         }
-        try {
+        {{/isPrimitiveType}}{{/isContainer}}
+        try { {{#isContainer}}{{^isPrimitiveType}}
             $this->data['{{name}}']->set($data);{{/isPrimitiveType}}{{#isPrimitiveType}}
             $this->data['{{name}}']->set(${{name}});{{/isPrimitiveType}}{{/isContainer}}{{^isContainer}}
             $this->data['{{name}}']->set(${{name}}{{^isPrimitiveType}}->getData(){{/isPrimitiveType}});{{/isContainer}}
         } catch (RestApi_TypeUtils_ParseException $e) {
-            throw new \InvalidArgumentException($e->getMessage())
+            throw new \InvalidArgumentException($e->getMessage());
         }
         return $this;
     }

--- a/modules/swagger-codegen/src/main/resources/gwtphp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/model.mustache
@@ -21,7 +21,8 @@ class {{modelPackage}}_{{classname}} implements JsonSerializable, RestApi_HasHea
     {{/hasMore}}{{/vars}}
 
     private static $fieldTypes = [{{#vars}}
-            '{{name}}' => ['{{#isPrimitiveType}}{{datatype}}{{/isPrimitiveType}}{{^isPrimitiveType}}mixed[]{{/isPrimitiveType}}'{{#hasDefaultValue}}, {{{defaultValue}}}{{/hasDefaultValue}}]{{#hasMore}},{{/hasMore}}{{/vars}}];
+            '{{name}}' => ['{{#isPrimitiveType}}{{datatype}}{{/isPrimitiveType}}{{^isPrimitiveType}}mixed[]{{/isPrimitiveType}}'{{#hasDefaultValue}}, {{{defaultValue}}}{{/hasDefaultValue}}]{{#hasMore}},{{/hasMore}}{{/vars}}
+    ];
 
     /**
      * @var RestApi_TypeUtils_Field[]

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Auth.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Auth.class.php
@@ -36,7 +36,12 @@ class RestApi_Auth {
         return self::$instance = static::getInstance($request);
     }
 
-    protected static function getInstance($request) {
+    /**
+     * @param \Slim\Http\Request $request
+     *
+     * @return RestApi_Auth
+     */
+    protected static function getInstance(\Slim\Http\Request $request) {
         return new RestApi_Auth($request);
     }
 
@@ -98,7 +103,7 @@ class RestApi_Auth {
      */
     public function checkScope($scopes) {
         if (!is_array($scopes)) {
-            $scopes = array($scopes);
+            $scopes = [$scopes];
         }
         if(empty($scopes)) {
             return;
@@ -117,5 +122,4 @@ class RestApi_Auth {
         }
         return $this->role->hasPrivilege($name);
     }
-    
 }

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/FieldValidityException.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/FieldValidityException.class.php
@@ -1,0 +1,23 @@
+<?php
+
+class RestApi_FieldValidityException extends Exception {
+
+    /** @var string */
+    private $fieldName;
+
+    /**
+     * @param string $fieldName
+     * @param string $message
+     */
+    public function __construct($fieldName, $message) {
+        parent::__construct($message);
+        $this->fieldName = $fieldName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFieldName() {
+        return $this->fieldName;
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HasHeaders.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HasHeaders.class.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * Auto generated code. DO NOT EDIT !!!!
+ */
 interface RestApi_HasHeaders {
     
     public function getHeaders();

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HasHeaders.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HasHeaders.class.php
@@ -4,6 +4,9 @@
  * Auto generated code. DO NOT EDIT !!!!
  */
 interface RestApi_HasHeaders {
-    
+
+    /**
+     * @return string[]
+     */
     public function getHeaders();
 }

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HasHeaders.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HasHeaders.class.php
@@ -1,0 +1,6 @@
+<?php
+
+interface RestApi_HasHeaders {
+    
+    public function getHeaders();
+}

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HeadersTrait.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HeadersTrait.class.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * Auto generated code. DO NOT EDIT !!!!
+ */
 trait RestApi_HeadersTrait {
     
     private $headers = [];

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HeadersTrait.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HeadersTrait.class.php
@@ -4,25 +4,45 @@
  * Auto generated code. DO NOT EDIT !!!!
  */
 trait RestApi_HeadersTrait {
-    
+
+    /**
+     * @var string[]
+     */
     private $headers = [];
 
+    /**
+     * @return string[]
+     */
     public function getHeaders() {
         return $this->headers;
     }
-    
+
+    /**
+     * @return $this
+     */
     public function clearHeaders() {
         $this->headers = [];
         
         return $this;
     }
-    
+
+    /**
+     * @param string $name
+     *
+     * @return $this
+     */
     public function removeHeader($name) {
         unset($this->headers[$name]);
         
         return $this;
     }
 
+    /**
+     * @param string $name
+     * @param string $value
+     *
+     * @return $this
+     */
     public function setHeader($name, $value) {
         $this->headers[$name] = $value;
         

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HeadersTrait.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/HeadersTrait.class.php
@@ -1,0 +1,28 @@
+<?php
+
+trait RestApi_HeadersTrait {
+    
+    private $headers = [];
+
+    public function getHeaders() {
+        return $this->headers;
+    }
+    
+    public function clearHeaders() {
+        $this->headers = [];
+        
+        return $this;
+    }
+    
+    public function removeHeader($name) {
+        unset($this->headers[$name]);
+        
+        return $this;
+    }
+
+    public function setHeader($name, $value) {
+        $this->headers[$name] = $value;
+        
+        return $this;
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Make.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Make.class.php
@@ -36,6 +36,10 @@ class RestApi_Make {
     public static function error($code = 500, $message = 'Unspecified error.', $cause = null) {
         return self::getInstance()->innerError($code, $message, $cause);
     }
+    
+    public static function errorMessage($message) {
+        return self::getInstance()->errorMessage($message);
+    }
 
     public static function result($body, $code = 200, $headers = array()) {
         return self::getInstance()->innerResult($body, $code, $headers);

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Make.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Make.class.php
@@ -31,7 +31,7 @@ class RestApi_Make {
      * @param int $code
      * @param string $message
      * @param Exception $cause
-     * @return RestApi_Result
+     * @return RestApi_ProcessingException
      */
     public static function error($code = 500, $message = 'Unspecified error.', $cause = null) {
         return self::getInstance()->innerError($code, $message, $cause);
@@ -41,6 +41,8 @@ class RestApi_Make {
      * @param int $code
      * @param string $message
      * @param Exception $cause
+     * @param string[] $headers
+     *
      * @return RestApi_Result
      */
     public static function errorResult($code = 500, $message = 'Unspecified error.', $cause = null, $headers = []) {
@@ -80,7 +82,9 @@ class RestApi_Make {
      * @param int $code
      * @param mixed $object json encodable body
      * @param Exception $cause
-     * @return RestApi_ProcessingException
+     * @param string[] $headers
+     *
+     * @return RestApi_Result
      */
     protected function innerErrorResult($code, $object, $cause = null, $headers = []) {
         $result = new RestApi_Result();

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Make.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Make.class.php
@@ -31,14 +31,20 @@ class RestApi_Make {
      * @param int $code
      * @param string $message
      * @param Exception $cause
-     * @return RestApi_ProcessingException
+     * @return RestApi_Result
      */
     public static function error($code = 500, $message = 'Unspecified error.', $cause = null) {
         return self::getInstance()->innerError($code, $message, $cause);
     }
-    
-    public static function errorMessage($message) {
-        return self::getInstance()->errorMessage($message);
+
+    /**
+     * @param int $code
+     * @param string $message
+     * @param Exception $cause
+     * @return RestApi_Result
+     */
+    public static function errorResult($code = 500, $message = 'Unspecified error.', $cause = null, $headers = []) {
+        return self::getInstance()->innerErrorResult($code, $message, $cause, $headers);
     }
 
     public static function result($body, $code = 200, $headers = array()) {
@@ -68,6 +74,21 @@ class RestApi_Make {
      */
     protected function innerOkResult() {
         return RestApi_Make::result(new stdClass());
+    }
+
+    /**
+     * @param int $code
+     * @param mixed $object json encodable body
+     * @param Exception $cause
+     * @return RestApi_ProcessingException
+     */
+    protected function innerErrorResult($code, $object, $cause = null, $headers = []) {
+        $result = new RestApi_Result();
+        $result->setCode($code);
+        $result->setBody(json_encode($object));
+        $this->initHeaders($headers);
+        $result->setHeaders($headers);
+        return $result;
     }
 
     /**

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Make.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Make.class.php
@@ -28,9 +28,13 @@ class RestApi_Make {
     }
 
     /**
+     * @deprecated use ProcessingException itself instead
+     * @see \RestApi_ProcessingException::__construct()
+     *
      * @param int $code
      * @param string $message
      * @param Exception $cause
+     *
      * @return RestApi_ProcessingException
      */
     public static function error($code = 500, $message = 'Unspecified error.', $cause = null) {
@@ -49,26 +53,34 @@ class RestApi_Make {
         return self::getInstance()->innerErrorResult($code, $message, $cause, $headers);
     }
 
-    public static function result($body, $code = 200, $headers = array()) {
+    /**
+     * @param mixed $body
+     * @param int $code
+     * @param string[] $headers
+     *
+     * @return RestApi_Result
+     */
+    public static function result($body, $code = 200, $headers = []) {
         return self::getInstance()->innerResult($body, $code, $headers);
     }
-    
+
     public static function run(\Slim\Slim $app) {
-    	return self::getInstance()->innerRun($app);
+        return self::getInstance()->innerRun($app);
     }
 
     /**
      * @return RestApi_Make
      */
     private static function getInstance() {
-        if(self::$instance == null) {
+        if (self::$instance == null) {
             self::init(new RestApi_Make());
         }
+
         return self::$instance;
     }
-    
+
     protected function innerRun(\Slim\Slim $app) {
-    	$app->run();
+        $app->run();
     }
 
     /**
@@ -92,6 +104,7 @@ class RestApi_Make {
         $result->setBody(json_encode($object));
         $this->initHeaders($headers);
         $result->setHeaders($headers);
+
         return $result;
     }
 
@@ -99,6 +112,7 @@ class RestApi_Make {
      * @param int $code
      * @param string $message
      * @param Exception $cause
+     *
      * @return RestApi_ProcessingException
      */
     protected function innerError($code, $message, $cause) {
@@ -108,6 +122,7 @@ class RestApi_Make {
         foreach ($headers as $header => $value) {
             $exception->setHeader($header, $value);
         }
+
         return $exception;
     }
 
@@ -115,6 +130,7 @@ class RestApi_Make {
      * @param mixed $body
      * @param int $code
      * @param string[] $headers
+     *
      * @return RestApi_Result
      */
     protected function innerResult($body, $code, $headers) {
@@ -123,6 +139,7 @@ class RestApi_Make {
         $result->setBody(json_encode($body));
         $this->initHeaders($headers);
         $result->setHeaders($headers);
+
         return $result;
     }
 
@@ -133,14 +150,14 @@ class RestApi_Make {
     }
 
     protected function initContentHeaders(array &$headers) {
-        if(isset($headers['Content-Type'])) {
+        if (isset($headers['Content-Type'])) {
             return;
         }
         $headers['Content-Type'] = 'application/json; charset=utf-8';
     }
 
     protected function initCacheHeaders(array &$headers) {
-        if(isset($headers['Cache-Control']) || isset($headers['Pragma']) || isset($headers['Expired'])) {
+        if (isset($headers['Cache-Control']) || isset($headers['Pragma']) || isset($headers['Expired'])) {
             return;
         }
         $headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0';
@@ -149,7 +166,7 @@ class RestApi_Make {
     }
 
     protected function initAccessControlHeaders(array &$headers) {
-        if(isset($headers['Access-Control-Allow-Origin'])) {
+        if (isset($headers['Access-Control-Allow-Origin'])) {
             return;
         }
         $headers['Access-Control-Allow-Origin'] = '*';

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Params.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Params.class.php
@@ -19,27 +19,39 @@ class RestApi_Params {
      * @var \Slim\Http\Request
      */
     private $request;
-    private $defaultValues = array();
+    private $defaultValues = [];
     private $scopes;
     
-    public function __construct(\Slim\Http\Request $request, array $scopes = array()) {
+    public function __construct(\Slim\Http\Request $request, array $scopes = []) {
         $this->request = $request;
         $this->scopes = $scopes;
     }
 
-    public function check($name, $required, $defaultValue, $type, array $allowedValues = null) {
+    /**
+     * @param string $name
+     * @param bool $required
+     * @param string $defaultValue
+     * @param string $type
+     * @param string[] $allowedValues
+     *
+     * @throws RestApi_ProcessingException
+     * @throws RestApi_TypeUtils_ParseException
+     */
+    public function check($name, $required, $defaultValue, $type, array $allowedValues = []) {
         $this->defaultValues[$name] = $defaultValue;
         $value = $this->get($name);
-        if($value == '') {
+        if($value === '') {
             if($required) {
-                throw RestApi_Make::error(400, sprintf('Param %s is required', $name));
+                throw new RestApi_ProcessingException(400, sprintf('Param %s is required', $name));
             } else {
                 // not required, no need to type check
                 return;
             }
         }
-        if ($allowedValues !== null && !in_array($value, $allowedValues)) {
-            throw RestApi_Make::error(400, sprintf('Only following values are allowed for %s: %s', $name, implode(',', $allowedValues)));
+        if (count($allowedValues) > 0 && !in_array($value, $allowedValues, true)) {
+            throw new RestApi_ProcessingException(400,
+                sprintf('Only following values are allowed for %s: %s', $name, implode(',', $allowedValues))
+            );
         }
         try {
             RestApi_TypeUtils_Field::of($type, $this->get($name));
@@ -49,6 +61,11 @@ class RestApi_Params {
         }
     }
 
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
     public function wasProvided($name) {
         $value = $this->request->get($name);
         if ($value === null) {
@@ -56,7 +73,12 @@ class RestApi_Params {
         }
         return $value !== null;
     }
-    
+
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
     public function get($name) {
         $value = $this->request->get($name);
         if ($value === null) {
@@ -65,22 +87,30 @@ class RestApi_Params {
         if ($value === null) {
             $value = @$this->defaultValues[$name];
         }
-        return $value;
+        return $value ?: '';
     }
-    
+
+    /**
+     * @return mixed
+     */
     public function getBody() {
         $body = $this->request->getBody();
         if ($body == '') {
-            return array();
+            return [];
         }
         return json_decode($body, true);
     }
-    
+
+    /**
+     * @param bool $includeOwn
+     *
+     * @return string[]
+     */
     public function getScopes($includeOwn = true) {
         if ($includeOwn) {
             return $this->scopes;
         }
-        $scopes = array();
+        $scopes = [];
         foreach ($this->scopes as $scope) {
             if (substr($scope, -strlen(self::OWN_SCOPE_SUFFIX)) === self::OWN_SCOPE_SUFFIX) {
                 continue;

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Params.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Params.class.php
@@ -28,36 +28,35 @@ class RestApi_Params {
     }
 
     /**
-     * @param string $name
+     * @param string $fieldName
      * @param bool $required
      * @param string $defaultValue
      * @param string $type
      * @param string[] $allowedValues
      *
+     * @throws RestApi_FieldValidityException
      * @throws RestApi_ProcessingException
-     * @throws RestApi_TypeUtils_ParseException
      */
-    public function check($name, $required, $defaultValue, $type, array $allowedValues = []) {
-        $this->defaultValues[$name] = $defaultValue;
-        $value = $this->get($name);
+    public function check($fieldName, $required, $defaultValue, $type, array $allowedValues = []) {
+        $this->defaultValues[$fieldName] = $defaultValue;
+        $value = $this->get($fieldName);
         if($value === '') {
             if($required) {
-                throw new RestApi_ProcessingException(400, sprintf('Param %s is required', $name));
-            } else {
-                // not required, no need to type check
-                return;
+                throw new RestApi_ProcessingException(400, sprintf('Param %s is required', $fieldName));
             }
+
+            // not required, no need to type check
+            return;
         }
         if (count($allowedValues) > 0 && !in_array($value, $allowedValues, true)) {
             throw new RestApi_ProcessingException(400,
-                sprintf('Only following values are allowed for %s: %s', $name, implode(',', $allowedValues))
+                sprintf('Only following values are allowed for %s: %s', $fieldName, implode(',', $allowedValues))
             );
         }
         try {
-            RestApi_TypeUtils_Field::of($type, $this->get($name));
+            RestApi_TypeUtils_Field::of($type, $this->get($fieldName));
         } catch (RestApi_TypeUtils_ParseException $e) {
-            $e->setFieldName($name);
-            throw $e;
+            throw new RestApi_FieldValidityException($fieldName, $e->getMessage());
         }
     }
 

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/ProcessingException.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/ProcessingException.class.php
@@ -34,7 +34,7 @@ class RestApi_ProcessingException extends Exception {
     public function asResult() {
         $result = new RestApi_Result();
         $result->setCode($this->getCode());
-        $result->setBody($this->getMessage());
+        $result->setBody(RestApi_Make::errorMessage($this->getMessage()));
         $result->setHeaders($this->headers);
         return $result;
     }

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/ProcessingException.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/ProcessingException.class.php
@@ -19,6 +19,9 @@ class RestApi_ProcessingException extends Exception implements RestApi_HasHeader
         parent::__construct($message, $code, $cause);
     }
 
+    /**
+     * @return RestApi_Result
+     */
     public function asResult() {
         $result = new RestApi_Result();
         $result->setCode($this->getCode());

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/ProcessingException.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/ProcessingException.class.php
@@ -11,31 +11,19 @@
 /**
  * Auto generated code. DO NOT EDIT !!!!
  */
-class RestApi_ProcessingException extends Exception {
+class RestApi_ProcessingException extends Exception implements RestApi_HasHeaders {
 
-    private $headers = array();
-
+    use RestApi_HeadersTrait;
+    
     public function __construct($code, $message, $cause = null) {
         parent::__construct($message, $code, $cause);
-    }
-
-    public function getHeaders() {
-        return $this->headers;
-    }
-
-    public function setHeader($name, $value) {
-        $this->headers[$name] = $value;
-    }
-
-    public function removeHeader($name) {
-        unset($this->headers[$name]);
     }
 
     public function asResult() {
         $result = new RestApi_Result();
         $result->setCode($this->getCode());
-        $result->setBody(RestApi_Make::errorMessage($this->getMessage()));
-        $result->setHeaders($this->headers);
+        $result->setBody($this->getMessage());
+        $result->setHeaders($this->getHeaders());
         return $result;
     }
 }

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Response.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Response.class.php
@@ -46,6 +46,7 @@ class RestApi_Response {
         if ($error instanceof RestApi_ProcessingException) {
             $code = $error->getCode();
             $headers = $error->getHeaders();
+            $message = $error->getMessage();
         } else if ($error instanceof RestApi_TypeUtils_ParseException) {
             $code = 400;
             $message = "Invalid field {$error->getFieldName()}: {$error->getMessage()}";

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Response.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Response.class.php
@@ -47,7 +47,7 @@ class RestApi_Response {
             $code = $error->getCode();
             $headers = $error->getHeaders();
             $message = $error->getMessage();
-        } else if ($error instanceof RestApi_TypeUtils_ParseException) {
+        } else if ($error instanceof RestApi_FieldValidityException) {
             $code = 400;
             $message = "Invalid field {$error->getFieldName()}: {$error->getMessage()}";
         }

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Result.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Result.class.php
@@ -13,30 +13,51 @@
  */
 class RestApi_Result {
 
+    /** @var int */
     private $code;
+    /** @var string */
     private $body;
-    private $headers = array();
+    /** @var string[] */
+    private $headers = [];
 
+    /**
+     * @return int
+     */
     public function getCode() {
         return $this->code;
     }
 
+    /**
+     * @param int $code
+     */
     public function setCode($code) {
         $this->code = $code;
     }
 
+    /**
+     * @return string
+     */
     public function getBody() {
         return $this->body;
     }
 
+    /**
+     * @param string $body
+     */
     public function setBody($body) {
         $this->body = $body;
     }
 
+    /**
+     * @return string[]
+     */
     public function getHeaders() {
         return $this->headers;
     }
 
+    /**
+     * @param string[] $headers
+     */
     public function setHeaders($headers) {
         $this->headers = $headers;
     }

--- a/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Role.class.php
+++ b/modules/swagger-codegen/src/main/resources/gwtphp/restapi/Role.class.php
@@ -13,16 +13,28 @@
  */
 class RestApi_Role {
 
-    private $privileges = array();
+    /** @var string[] */
+    private $privileges = [];
 
-    protected function addPrivilege($name) {
-        $this->privileges[$name] = true;
+    /**
+     * @param string $privilegeName
+     */
+    protected function addPrivilege($privilegeName) {
+        $this->privileges[$privilegeName] = true;
     }
 
-    public function hasPrivilege($name) {
-        return array_key_exists($name, $this->privileges);
+    /**
+     * @param string $privilegeName
+     *
+     * @return bool
+     */
+    public function hasPrivilege($privilegeName) {
+        return array_key_exists($privilegeName, $this->privileges);
     }
-    
+
+    /**
+     * @return string[]
+     */
     public function getPrivileges() {
     	return array_keys($this->privileges);
     }


### PR DESCRIPTION
QualityUnit/la-issues#6327

1. Api by uz malo vracat iba contnet-type application/json (XSS fix).
2. Konecne fix na specialne znaky v enume.
3. Ci uz sa v kode pouzije `throw new RestApi_ProcessingException(..)`, alebo `RestApi_Make::error(..)` vzdy sa to zabali do ErrorResponse modelu. Zatial v iba LA. Ak si to implementuju v PAP-e, tak by to malo fungovat tam, tam nepouzivaju ErrorResponse, alebo Message.